### PR TITLE
removing rh-avatar test from test/index.html

### DIFF
--- a/test/index.html
+++ b/test/index.html
@@ -16,7 +16,6 @@
         ".wct-kludge/elements/cp-onebox/test/index.html",
         ".wct-kludge/elements/cp-tabs/test/index.html",
         ".wct-kludge/elements/cp-tooltip/test/index.html",
-        ".wct-kludge/elements/rh-avatar/test/index.html",
         ".wct-kludge/elements/rh-button/test/index.html",
         ".wct-kludge/elements/rh-card/test/index.html",
         ".wct-kludge/elements/rh-cta/test/index.html",


### PR DESCRIPTION
This change was added by accident. We need to remove it for our tests to pass.