### PR TITLE
ignoring node_modules

### DIFF
--- a/spandx.config.js
+++ b/spandx.config.js
@@ -8,6 +8,12 @@ module.exports = {
     "/elements": "./elements",
     "/doc": "./doc",
     "/favicon.ico": "./favicon.ico",
-    "/": "./node_modules/"
+    "/": "./node_modules"
+  },
+  bs: {
+    watchOptions: {
+      ignoreInitial: true,
+      ignored: ["node_modules"]
+    }
   }
 };


### PR DESCRIPTION
There are about 86,000 files in node_modules. We need to tell Browsersync to stop watching these files. This dramatically speeds up page load times and gets rid of the Javascript head error that some of us were seeing in the command line.