### PR TITLE
make rhelement npm scripts identical to other elements

### DIFF
--- a/elements/rhelement/package.json
+++ b/elements/rhelement/package.json
@@ -13,7 +13,7 @@
   "main": "index.js",
   "scripts": {
     "build": "../../node_modules/.bin/gulp && ../../node_modules/.bin/prettier --ignore-path ../../.prettierignore --write '**/*.{js,json}'",
-    "start": "../../node_modules/.bin/gulp dev & npm run serve",
+    "dev": "../../node_modules/.bin/gulp dev",
     "test": "../../node_modules/.bin/wct --configFile ../../wct.conf.json node_modules/@rhelements/rhelement/test/"
   },
   "author": {


### PR DESCRIPTION
rhelement.js had an `npm start` script which no other elements have, and it was missing `npm run dev`.  This PR fixes that and makes it consistent with other elements.