### PR TITLE
skip diff and merging on *.umd.js files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+elements/*/*.umd.js     -diff -merge
+elements/*/*.umd.js.map -diff -merge
+themes/*/*.umd.js       -diff -merge
+themes/*/*.umd.js.map   -diff -merge


### PR DESCRIPTION
This flags `elements/*/*.umd.js` files as binary, so that git diff doesn't do a text diff on them (it just says "this file changed"), and git merge just accepts the newer version without trying to do a text merge.

Ideally this would be done on every generated file (ie, `rh-card.umd.js` and `rh-card.js` for example), but matching the ESM version (`rh-card.js`) is much harder.  `*.umd.js` is easy to match precisely, but `*.js` overreaches and matches the gulpfile, storybook file, and rollup config as well.  So for now at least, this only applies to the UMD builds.