### PR TITLE
add a new dev script at the root

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "start": "npm run doc-listing-inject && spandx",
     "lerna": "lerna",
     "test": "npm run build && wct --configFile wct.conf.json test/index.html",
+    "dev": "bash scripts/dev.sh",
     "build": "lerna run build",
     "clean": "rm -rf node_modules package-lock.json {elements,themes}/*/{node_modules,package-lock.json}",
     "bootstrap": "lerna bootstrap --hoist",

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+CMD="npm run lerna -- run dev --parallel --no-bail --include-filtered-dependencies"
+
+for el in "$@"; do
+  CMD="$CMD --scope \"*/$el\""
+  echo $CMD
+done
+
+eval $CMD


### PR DESCRIPTION
This adds a `npm run dev` script to the root of the repo.  Prior to this, `npm run dev` only existed inside each element directory.  This new script will watch every element by default, and offers a very easy way to watch only the element you care about.

A companion PR (https://github.com/RHElements/rhelements-documentation/pull/12) is open for updating the documentation, and should be merged whenever this PR is merged.  Follow [this link](https://github.com/RHElements/rhelements-documentation/blob/ab1c682dde86682f35fb36532fa64b40d0d828dc/content/develop/step-1a.md#develop) to see the docs for this feature.


